### PR TITLE
Update xsns_57_tsl2591.ino - report channel values in JSON as in TSL2561

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
@@ -38,6 +38,8 @@ Adafruit_TSL2591 tsl = Adafruit_TSL2591();
 uint8_t tsl2591_type = 0;
 uint8_t tsl2591_valid = 0;
 float tsl2591_lux = 0;
+uint16_t tsl2591_lux_bb = 0;
+uint16_t tsl2591_lux_ir = 0;
 
 tsl2591Gain_t gain_enum_array[4] = {TSL2591_GAIN_LOW,TSL2591_GAIN_MED,TSL2591_GAIN_HIGH,TSL2591_GAIN_MAX};
 tsl2591IntegrationTime_t int_enum_array[6] = {TSL2591_INTEGRATIONTIME_100MS,TSL2591_INTEGRATIONTIME_200MS,TSL2591_INTEGRATIONTIME_300MS,TSL2591_INTEGRATIONTIME_400MS,TSL2591_INTEGRATIONTIME_500MS,TSL2591_INTEGRATIONTIME_600MS};
@@ -62,6 +64,8 @@ void Tsl2591Read(void)
   ir = lum >> 16;
   full = lum & 0xFFFF;
   tsl2591_lux = tsl.calculateLux(full, ir);
+  tsl2591_lux_bb = full;
+  tsl2591_lux_ir = ir;
   tsl2591_valid = 1;
 }
 
@@ -81,7 +85,8 @@ void Tsl2591Show(bool json)
     char lux_str[10];
     dtostrf(tsl2591_lux, sizeof(lux_str)-1, 3, lux_str);
     if (json) {
-      ResponseAppend_P(PSTR(",\"TSL2591\":{\"" D_JSON_ILLUMINANCE "\":%s}"), lux_str);
+      ResponseAppend_P(PSTR(",\"TSL2591\":{\"" D_JSON_ILLUMINANCE "\":%s,\"IR\":%u,\"Broadband\":%u}"),
+        lux_str,tsl2591_lux_ir,tsl2591_lux_ir);
 #ifdef USE_DOMOTICZ
       if (0 == TasmotaGlobal.tele_period) { DomoticzSensor(DZ_ILLUMINANCE, tsl2591_lux); }
 #endif  // USE_DOMOTICZ


### PR DESCRIPTION
Add the raw infrared and broadband channels of the sensor to the JSON report like is done in the driver for TSL2561

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
