### PR TITLE
Fix to correctly detect all known chip versions

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_16_tsl2561.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_16_tsl2561.ino
@@ -75,7 +75,8 @@ void Tsl2561Detect(void)
     if (!Tsl.id(id)) return;
     // check the correct ID was returned
     // datasheet says reg 0xA (ID) returns 0x1r (r = nibble revision)
-    if ((id & 0xF0) != 0x10) return;    
+    // current version returns 0x5r
+    if ((id & 0xF0) != 0x10 && (id & 0xF0) != 0x50) return;    
     if (Tsl.on()) {
       tsl2561_type = 1;
       I2cSetActiveFound(Tsl.address(), tsl2561_types);


### PR DESCRIPTION
Fix do deal with the current generation of the chip that returns 5 is ID

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250707
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
